### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,4 @@
 [book]
 authors = ["Michael Lamparski"]
-multilingual = false
 src = "src"
 title = "Unsafe Gotchas"


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10